### PR TITLE
preventDefault

### DIFF
--- a/src/js/touch-carousel.js
+++ b/src/js/touch-carousel.js
@@ -58,7 +58,10 @@
   TouchCarousel.prototype._regTouchGestures = function() {
     this.$itemsWrapper
       .add(this.$indicators) // fixes issue #9
-      .hammer({ drag_lock_to_axis: true })
+      .hammer({ 
+        drag_lock_to_axis: true,
+        preventDefault: true,
+      })
       .on("release dragleft dragright swipeleft swiperight", $.proxy(this._handleGestures, this));
   }
 
@@ -141,8 +144,6 @@
   }
 
   TouchCarousel.prototype._handleGestures = function( e ) {
-    // disable browser scrolling
-    e.gesture.preventDefault();
 
     if(this.sliding) return;
 


### PR DESCRIPTION
Prevent the default gesture on the browser... so it doesn't slide up and down ... the e.prevenDefault is not working for me... it might be because of the newer hammer js version ... i dont know... 

this way it seems to work
